### PR TITLE
Add F# support and refactor command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+
+# rider
+.idea/

--- a/AoC-Template.sln
+++ b/AoC-Template.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AoC-Template", "src\AoC-Template\AoC-Template.csproj", "{191202B7-9290-4CB8-8F9F-A8F021204A71}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "AoCFSharp", "AoCFSharp\AoCFSharp.fsproj", "{49F90BB6-C326-417C-B78E-287C3F61BE6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{191202B7-9290-4CB8-8F9F-A8F021204A71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{191202B7-9290-4CB8-8F9F-A8F021204A71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{191202B7-9290-4CB8-8F9F-A8F021204A71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49F90BB6-C326-417C-B78E-287C3F61BE6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49F90BB6-C326-417C-B78E-287C3F61BE6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49F90BB6-C326-417C-B78E-287C3F61BE6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49F90BB6-C326-417C-B78E-287C3F61BE6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AoCFSharp/AoCFSharp.fsproj
+++ b/AoCFSharp/AoCFSharp.fsproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Compile Include="Days\Day01.fs" />
+    </ItemGroup>
+
+</Project>

--- a/AoCFSharp/Days/Day01.fs
+++ b/AoCFSharp/Days/Day01.fs
@@ -1,0 +1,7 @@
+module AoCFSharp.Days.Day01
+
+let part1 (input : string) =
+    "part1"
+    
+let part2 (input : string) =
+    "part2"

--- a/src/AoC-Template/AoC-Template.csproj
+++ b/src/AoC-Template/AoC-Template.csproj
@@ -10,12 +10,17 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.10"/>
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 
     <ItemGroup>
         <None Update="Inputs\**">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\AoCFSharp\AoCFSharp.fsproj" />
     </ItemGroup>
 
 

--- a/src/AoC-Template/Program.cs
+++ b/src/AoC-Template/Program.cs
@@ -7,7 +7,8 @@ namespace AdventOfCode2022;
 
 internal class Program
 {
-    public static IEnumerable<Type> DayInputs = null!;
+    public static IEnumerable<Type> DayInputTypes = null!;
+    public static IEnumerable<BaseChallengeFSharp> DayInputFSharp = null!;
 
     private static void Main(string[] args)
     {
@@ -50,11 +51,12 @@ internal class Program
                 BenchmarkRunner.Run<BulkBenchFSharp>();
                 break;
             case ("c#",_):
-                DayInputs = GetTypes(daysList);
+                DayInputTypes = GetTypes(daysList);
                 BenchmarkRunner.Run<DayBenchCSharp>();
                 break;
             case ("f#",_):
-                throw new NotImplementedException("NYI");
+                DayInputFSharp = GetFSharpChallenges(daysList);
+                BenchmarkRunner.Run<DayBenchFSharp>();
                 break;
         }
 
@@ -69,6 +71,19 @@ internal class Program
                     Console.WriteLine($"No challenge found for day {day}.");
                 else
                     yield return type;
+            }
+        }
+
+        IEnumerable<BaseChallengeFSharp> GetFSharpChallenges(IEnumerable<int> days)
+        {
+            List<(BaseChallengeFSharp challenge, int)> challenges = BulkBenchFSharp.Challenges().Select(c => (c, int.Parse(c.DayIdentifier))).ToList();
+            foreach (var day in days)
+            {
+                var challenge = challenges.FirstOrDefault(c => c.Item2 == day).challenge;
+                if(challenge is null) 
+                    Console.WriteLine($"No challenge found for day {day}.");
+                else
+                    yield return challenge;
             }
         }
     }

--- a/src/AoC-Template/Program.cs
+++ b/src/AoC-Template/Program.cs
@@ -93,22 +93,42 @@ internal class Program
         switch(lang)
         {
             case "c#":
-                foreach (var day in days)
-                {
-                    var type = ReflectionUtilities.GetChallengeType(day);
-                    if(type is null)
-                        Console.WriteLine($"No challenge found for day {day}.");
-                    else
-                    {
-                        var challenge = (BaseChallenge)Activator.CreateInstance(type)!;
-                        Console.WriteLine($"Day {day} part 1: {challenge.SolvePartOne()}");
-                        Console.WriteLine($"Day {day} part 2: {challenge.SolvePartTwo()}");
-                    }
-                }
+                RunCSharpWithoutBench(days);
                 break;
             case "f#":
-                throw new NotImplementedException("NYI");
+                RunFSharpWithoutBench(days);
                 break;
+        }
+    }
+
+    private static void RunFSharpWithoutBench(IEnumerable<int> days)
+    {
+        foreach (var day in days)
+        {
+            var challenge = BulkBenchFSharp.Challenges().FirstOrDefault(c => int.Parse(c.DayIdentifier) == day);
+            if (challenge is null)
+                Console.WriteLine($"No challenge found for day {day}.");
+            else
+            {
+                Console.WriteLine($"Day {day} part 1: {challenge.SolvePartOne()}");
+                Console.WriteLine($"Day {day} part 2: {challenge.SolvePartTwo()}");
+            }
+        }
+    }
+
+    private static void RunCSharpWithoutBench(IEnumerable<int> days)
+    {
+        foreach (var day in days)
+        {
+            var type = ReflectionUtilities.GetChallengeType(day);
+            if (type is null)
+                Console.WriteLine($"No challenge found for day {day}.");
+            else
+            {
+                var challenge = (BaseChallenge)Activator.CreateInstance(type)!;
+                Console.WriteLine($"Day {day} part 1: {challenge.SolvePartOne()}");
+                Console.WriteLine($"Day {day} part 2: {challenge.SolvePartTwo()}");
+            }
         }
     }
 }

--- a/src/AoC-Template/Program.cs
+++ b/src/AoC-Template/Program.cs
@@ -14,7 +14,7 @@ internal class Program
     {
         var langOption = new Option<string>("--lang", () => "c#", "The language to run in.");
         var daysOption = new Option<IEnumerable<int>>("--days", "The days to run.") {AllowMultipleArgumentsPerToken = true};
-        var daysArgument = new Argument<IEnumerable<int>>("days", "The days to run.");
+        var daysOptionInRun = new Option<IEnumerable<int>>("--days", "The days to run.") {AllowMultipleArgumentsPerToken = true, IsRequired = true};
         
         var rootCommand = new RootCommand
         {
@@ -25,13 +25,13 @@ internal class Program
         
         var runCommand = new Command("run", "Run without benchmark.");
         runCommand.AddOption(langOption);
-        runCommand.AddOption(daysOption);
-        runCommand.SetHandler(RunWithoutBench, langOption, daysOption);
+        runCommand.AddOption(daysOptionInRun);
+        runCommand.SetHandler(RunWithoutBench, langOption, daysOptionInRun);
         
         var benchCommand = new Command("bench", "Run with benchmark.");
         benchCommand.AddOption(langOption);
-        benchCommand.AddArgument(daysArgument);
-        benchCommand.SetHandler(RunWithBench, langOption, daysArgument);
+        benchCommand.AddOption(daysOption);
+        benchCommand.SetHandler(RunWithBench, langOption, daysOption);
         
         rootCommand.AddCommand(runCommand);
         rootCommand.AddCommand(benchCommand);

--- a/src/AoC-Template/Running/BaseChallengeFSharp.cs
+++ b/src/AoC-Template/Running/BaseChallengeFSharp.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace AdventOfCode2022.Running;
+
+public partial class BaseChallengeFSharp
+{
+    public BaseChallengeFSharp(MemberInfo t, IEnumerable<MethodInfo> methods)
+    {
+        DayIdentifier = DayRegex().Match(t.Name).Value;
+        var methodInfos = methods.ToList();
+        Part1 = methodInfos.First(m => m.Name == "part1");
+        Part2 = methodInfos.First(m => m.Name == "part2");
+    }
+
+    public override string ToString() => $"Day {DayIdentifier}";
+
+    [GeneratedRegex(@"\d+")]
+    private static partial Regex DayRegex();
+
+    private const string InputDir = "Inputs";
+    private const string InputFileType = ".txt";
+
+    private string GetInput() => File.ReadAllText(Path.Combine(InputDir, $"{DayIdentifier}{InputFileType}"));
+
+    private string DayIdentifier { get; init; }
+    private MethodInfo Part1 { get; init; }
+    private MethodInfo Part2 { get; init; }
+
+    public string SolvePartOne() => Part1.Invoke(null, new object?[] { GetInput() }) as string ?? string.Empty;
+    public string SolvePartTwo() => Part2.Invoke(null, new object?[] { GetInput() }) as string ?? string.Empty;
+}

--- a/src/AoC-Template/Running/BaseChallengeFSharp.cs
+++ b/src/AoC-Template/Running/BaseChallengeFSharp.cs
@@ -23,9 +23,9 @@ public partial class BaseChallengeFSharp
 
     private string GetInput() => File.ReadAllText(Path.Combine(InputDir, $"{DayIdentifier}{InputFileType}"));
 
-    private string DayIdentifier { get; init; }
-    private MethodInfo Part1 { get; init; }
-    private MethodInfo Part2 { get; init; }
+    public string DayIdentifier { get; }
+    private MethodInfo Part1 { get; }
+    private MethodInfo Part2 { get; }
 
     public string SolvePartOne() => Part1.Invoke(null, new object?[] { GetInput() }) as string ?? string.Empty;
     public string SolvePartTwo() => Part2.Invoke(null, new object?[] { GetInput() }) as string ?? string.Empty;

--- a/src/AoC-Template/Running/BulkBenchCSharp.cs
+++ b/src/AoC-Template/Running/BulkBenchCSharp.cs
@@ -6,7 +6,7 @@ namespace AdventOfCode2022.Running;
 
 [MemoryDiagnoser(false)]
 [Orderer(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical)]
-public class BulkBench
+public class BulkBenchCSharp
 {
     private BaseChallenge _challenge = null!;
 

--- a/src/AoC-Template/Running/BulkBenchFSharp.cs
+++ b/src/AoC-Template/Running/BulkBenchFSharp.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using AoCFSharp.Days;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+
+namespace AdventOfCode2022.Running;
+
+[MemoryDiagnoser(false)]
+[Orderer(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical)]
+public class BulkBenchFSharp
+{
+    [ParamsSource(nameof(Challenges))]
+    // ReSharper disable once MemberCanBePrivate.Global
+    // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
+    public static BaseChallengeFSharp Challenge { get; set; } = null!;
+
+    [Benchmark(Description = "Part 1")]
+    public string PartOne() => Challenge.SolvePartOne();
+
+    [Benchmark(Description = "Part 2")]
+    public string PartTwo() => Challenge.SolvePartTwo();
+    public static IEnumerable<BaseChallengeFSharp> Challenges()
+    {
+        return Assembly
+                   .GetAssembly(typeof(Day01))?
+                   .GetTypes()
+                   .Select(t => (t, t.GetMethods()))
+                   .Where(tup => tup.Item2.Any(m => m.Name == "part1") &&
+                                 tup.Item2.Any(m => m.Name == "part2"))
+                   .Select(tup => (tup.t, tup.Item2.Where(m => m.Name is "part1" or "part2")))
+                   .Select(tup => new BaseChallengeFSharp(tup.t, tup.Item2))
+               ?? Enumerable.Empty<BaseChallengeFSharp>();
+    }
+}

--- a/src/AoC-Template/Running/DayBenchCSharp.cs
+++ b/src/AoC-Template/Running/DayBenchCSharp.cs
@@ -5,11 +5,15 @@ namespace AdventOfCode2022.Running;
 
 [MemoryDiagnoser(false)]
 [Orderer(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical)]
-public class Bench
+public class DayBenchCSharp
 {
 
     private BaseChallenge _challenge = null!;
-    private static Type Challenge => Program.DayInput;
+    public static IEnumerable<Type> Challenges => Program.DayInputs;
+    
+    [ParamsSource(nameof(Challenges))]
+    // ReSharper disable once FieldCanBeMadeReadOnly.Local
+    public Type Challenge = null!;
 
     [GlobalSetup] public void Setup()
     {

--- a/src/AoC-Template/Running/DayBenchFSharp.cs
+++ b/src/AoC-Template/Running/DayBenchFSharp.cs
@@ -5,24 +5,18 @@ namespace AdventOfCode2022.Running;
 
 [MemoryDiagnoser(false)]
 [Orderer(SummaryOrderPolicy.Method, MethodOrderPolicy.Alphabetical)]
-public class DayBenchCSharp
+public class DayBenchFSharp
 {
 
-    private BaseChallenge _challenge = null!;
-    public static IEnumerable<Type> Challenges => Program.DayInputTypes;
+    public static IEnumerable<BaseChallengeFSharp> Challenges => Program.DayInputFSharp;
     
     [ParamsSource(nameof(Challenges))]
     // ReSharper disable once FieldCanBeMadeReadOnly.Local
-    public Type Challenge = null!;
-
-    [GlobalSetup] public void Setup()
-    {
-        _challenge = (BaseChallenge)Activator.CreateInstance(Challenge)!;
-    }
+    public BaseChallengeFSharp Challenge = null!;
 
     [Benchmark(Description = "Part 1")] public string PartOne()
-        => _challenge.SolvePartOne();
+        => Challenge.SolvePartOne();
 
     [Benchmark(Description = "Part 2")] public string PartTwo()
-        => _challenge.SolvePartTwo();
+        => Challenge.SolvePartTwo();
 }

--- a/src/AoC-Template/Utilities/ReflectionUtilities.cs
+++ b/src/AoC-Template/Utilities/ReflectionUtilities.cs
@@ -1,14 +1,24 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using AdventOfCode2022.Running;
 
 namespace AdventOfCode2022.Utilities;
 
-public static class ReflectionUtilities
+public static partial class ReflectionUtilities
 {
+    [GeneratedRegex(@"\d+")]
+    private static partial Regex DayRegex();
     public static bool TryGetChallengeType(string challengeType, [NotNullWhen(true)] out Type? challenge)
     {
         challenge = Assembly.GetExecutingAssembly().GetTypes().FirstOrDefault(predicate: t => t.Name == challengeType);
 
         return challenge is not null;
     }
+
+    public static Type? GetChallengeType(int day) => Assembly
+        .GetExecutingAssembly()
+        .GetTypes()
+        .Where(t => t.BaseType == typeof(BaseChallenge))
+        .FirstOrDefault(predicate: t => int.Parse(DayRegex().Match(t.Name).Value) == day);
 }


### PR DESCRIPTION
- Added explicit F# support
- Added command line switch for run or bench (default is bench, if no command is specified)
- Added command line switch for C# and F# (default is C#)
- Added command line switch for days (required if run command is selected)
Examples: 
`run --lang f# --days 01 02 03 04`
`bench --lang c# --days 01 --days 02`